### PR TITLE
list in show (sublist) , tab brick, CustomBrick (controller brick and template brick)

### DIFF
--- a/src/Brick/AbstractBasicBrickFactory.php
+++ b/src/Brick/AbstractBasicBrickFactory.php
@@ -6,24 +6,24 @@ namespace Lle\CruditBundle\Brick;
 
 use Lle\CruditBundle\Contracts\BrickInterface;
 use Lle\CruditBundle\Exception\CruditException;
-use Lle\CruditBundle\Resolver\RessourceResolver;
+use Lle\CruditBundle\Resolver\ResourceResolver;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 abstract class AbstractBasicBrickFactory implements BrickInterface
 {
-    /** @var RessourceResolver  */
-    protected $ressourceResolver;
+    /** @var ResourceResolver  */
+    protected $resourceResolver;
 
     /** @var RequestStack  */
     protected $requestStack;
 
     public function __construct(
-        RessourceResolver $ressourceResolver,
+        ResourceResolver $resourceResolver,
         RequestStack $requestStack
     ) {
         $this->requestStack = $requestStack;
-        $this->ressourceResolver = $ressourceResolver;
+        $this->resourceResolver = $resourceResolver;
     }
 
     protected function getRequest(): Request

--- a/src/Brick/AbstractBrickConfig.php
+++ b/src/Brick/AbstractBrickConfig.php
@@ -6,6 +6,7 @@ namespace Lle\CruditBundle\Brick;
 
 use Lle\CruditBundle\Contracts\BrickConfigInterface;
 use Lle\CruditBundle\Contracts\CrudConfigInterface;
+use Lle\CruditBundle\Contracts\DatasourceInterface;
 
 abstract class AbstractBrickConfig implements BrickConfigInterface
 {
@@ -21,6 +22,11 @@ abstract class AbstractBrickConfig implements BrickConfigInterface
     public function getCrudConfig(): CrudConfigInterface
     {
         return $this->crudConfig;
+    }
+
+    public function getDatasource(): DatasourceInterface
+    {
+        return $this->crudConfig->getDatasource();
     }
 
     public function getConfig(): array

--- a/src/Brick/ControllerBrick/ControllerConfig.php
+++ b/src/Brick/ControllerBrick/ControllerConfig.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lle\CruditBundle\Brick\ControllerBrick;
+
+use Lle\CruditBundle\Brick\AbstractBrickConfig;
+
+class ControllerConfig extends AbstractBrickConfig
+{
+    /** @var array  */
+    private $options = [];
+
+    public static function new(array $options = []): self
+    {
+        return new self($options);
+    }
+
+    public function __construct(array $options)
+    {
+        $this->options = $options;
+    }
+
+    public function getConfig(): array
+    {
+        return $this->options;
+    }
+}

--- a/src/Brick/ControllerBrick/ControllerFactory.php
+++ b/src/Brick/ControllerBrick/ControllerFactory.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lle\CruditBundle\Brick\ControllerBrick;
+
+use Lle\CruditBundle\Brick\AbstractBasicBrickFactory;
+use Lle\CruditBundle\Dto\BrickView;
+use Lle\CruditBundle\Contracts\BrickConfigInterface;
+use Lle\CruditBundle\Dto\ResourceView;
+
+class ControllerFactory extends AbstractBasicBrickFactory
+{
+
+    public function support(BrickConfigInterface $brickConfigurator): bool
+    {
+        return (ControllerConfig::class === get_class($brickConfigurator));
+    }
+
+    public function buildView(BrickConfigInterface $brickConfigurator): BrickView
+    {
+        /** @var ControllerConfig $brickConfigurator */
+        $view = new BrickView(spl_object_hash($brickConfigurator));
+        $view
+            ->setTemplate('@LleCrudit/brick/controller')
+            ->setConfig($brickConfigurator->getConfig())
+            ->setData(['resource' => $this->getResourceView($brickConfigurator)]);
+        return $view;
+    }
+
+    private function getResourceView(ControllerConfig $brickConfigurator): ?ResourceView
+    {
+        $item = $brickConfigurator->getDataSource()->get($this->getRequest()->get('id'));
+        if ($item) {
+            return $this->resourceResolver->resolve(
+                $item,
+                [],
+                $brickConfigurator->getDataSource()
+            );
+        }
+        return null;
+    }
+}

--- a/src/Brick/ListBrick/ListFactory.php
+++ b/src/Brick/ListBrick/ListFactory.php
@@ -8,10 +8,25 @@ use Lle\CruditBundle\Brick\AbstractBasicBrickFactory;
 use Lle\CruditBundle\Contracts\BrickConfigInterface;
 use Lle\CruditBundle\Dto\BrickView;
 use Lle\CruditBundle\Dto\Field\Field;
-use Lle\CruditBundle\Dto\RessourceView;
+use Lle\CruditBundle\Dto\ResourceView;
+use Lle\CruditBundle\Registry\DatasourceRegistry;
+use Lle\CruditBundle\Resolver\ResourceResolver;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 class ListFactory extends AbstractBasicBrickFactory
 {
+    /** @var DatasourceRegistry */
+    private $datasourceRegistry;
+
+    public function __construct(
+        ResourceResolver $resourceResolver,
+        RequestStack $requestStack,
+        DatasourceRegistry $datasourceRegistry
+    ) {
+        $this->datasourceRegistry = $datasourceRegistry;
+        parent::__construct($resourceResolver, $requestStack);
+    }
+
     public function support(BrickConfigInterface $brickConfigurator): bool
     {
         return (ListConfig::class === get_class($brickConfigurator));
@@ -37,17 +52,41 @@ class ListFactory extends AbstractBasicBrickFactory
         return $brickConfigurator->getFields();
     }
 
-    /** @return RessourceView[] */
+    /** @return ResourceView[] */
     private function getLines(ListConfig $brickConfigurator): array
     {
         $lines = [];
         if ($brickConfigurator->getDataSource() !== null) {
-            foreach ($brickConfigurator->getDataSource()->list() as $item) {
-                $lines[] = $this->ressourceResolver->resolve(
-                    $item,
-                    $this->getFields($brickConfigurator),
-                    $brickConfigurator->getDataSource()
-                );
+            if ($this->getRequest()->get('id')) {
+                $datasource = $brickConfigurator->getClassName() !== null ?
+                    $this->datasourceRegistry->getByClass($brickConfigurator->getClassName()) :
+                    $brickConfigurator->getDatasource();
+                $resource = $brickConfigurator->getDataSource()->get($this->getRequest()->get('id'));
+                $fieldName = $brickConfigurator->getFieldNameAssociation() ??
+                    $datasource->getAssociationFieldName($brickConfigurator->getDataSource()->getClassName());
+                $query = $datasource->createQuery('assoc');
+                if ($brickConfigurator->hasCatchQueryAssociation()) {
+                    $query = $brickConfigurator->catchQueryAssociation($query, 'assoc');
+                } elseif ($fieldName !== null) {
+                    $query
+                        ->where('assoc. ' . $fieldName . ' = :id')
+                        ->setParameter('id', $this->getRequest()->get('id'));
+                }
+                foreach ($query->execute() as $item) {
+                    $lines[] = $this->resourceResolver->resolve(
+                        $item,
+                        $this->getFields($brickConfigurator),
+                        $datasource
+                    );
+                }
+            } else {
+                foreach ($brickConfigurator->getDataSource()->list() as $item) {
+                    $lines[] = $this->resourceResolver->resolve(
+                        $item,
+                        $this->getFields($brickConfigurator),
+                        $brickConfigurator->getDataSource()
+                    );
+                }
             }
         }
         return $lines;

--- a/src/Brick/ShowBrick/ShowFactory.php
+++ b/src/Brick/ShowBrick/ShowFactory.php
@@ -8,7 +8,7 @@ use Lle\CruditBundle\Brick\AbstractBasicBrickFactory;
 use Lle\CruditBundle\Contracts\BrickConfigInterface;
 use Lle\CruditBundle\Dto\BrickView;
 use Lle\CruditBundle\Dto\Field\Field;
-use Lle\CruditBundle\Dto\RessourceView;
+use Lle\CruditBundle\Dto\ResourceView;
 
 class ShowFactory extends AbstractBasicBrickFactory
 {
@@ -38,11 +38,11 @@ class ShowFactory extends AbstractBasicBrickFactory
         return $brickConfigurator->getFields();
     }
 
-    private function getItem(ShowConfig $brickConfigurator, string $id): ?RessourceView
+    private function getItem(ShowConfig $brickConfigurator, string $id): ?ResourceView
     {
         $item = $brickConfigurator->getDataSource()->get($id);
         if ($item) {
-            return $this->ressourceResolver->resolve(
+            return $this->resourceResolver->resolve(
                 $item,
                 $this->getFields($brickConfigurator),
                 $brickConfigurator->getDataSource()

--- a/src/Brick/TabBrick/Tab.php
+++ b/src/Brick/TabBrick/Tab.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lle\CruditBundle\Brick\TabBrick;
+
+use Lle\CruditBundle\Contracts\BrickConfigInterface;
+
+class Tab
+{
+
+    /** @var BrickConfigInterface[] */
+    private $bricks;
+
+    /** @var string */
+    private $label;
+
+    public static function new(string $label, array $bricks = []): self
+    {
+        return (new self($bricks))
+            ->setLabel($label)
+            ;
+    }
+
+    private function __construct(array $bricks)
+    {
+        $this->bricks = $bricks;
+    }
+
+    public function setLabel(string $label): self
+    {
+        $this->label = $label;
+        return $this;
+    }
+
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+
+    public function add(BrickConfigInterface $brick): self
+    {
+        $this->bricks[] = $brick;
+        return $this;
+    }
+
+    /** @return BrickConfigInterface[] */
+    public function getBrick(): array
+    {
+        return $this->bricks;
+    }
+}

--- a/src/Brick/TabBrick/TabConfig.php
+++ b/src/Brick/TabBrick/TabConfig.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lle\CruditBundle\Brick\TabBrick;
+
+use Lle\CruditBundle\Brick\AbstractBrickConfig;
+use Lle\CruditBundle\Contracts\BrickConfigInterface;
+
+class TabConfig extends AbstractBrickConfig
+{
+    /** @var Tab[] */
+    private $tabs = [];
+
+    public static function new(array $options = []): self
+    {
+        return new self($options);
+    }
+
+    public function __construct(array $options)
+    {
+        $this->tabs = $options['tabs'] ?? [];
+    }
+
+    /** @return Tab[] */
+    public function getTabs(): array
+    {
+        return $this->tabs;
+    }
+
+    public function add(string $label, BrickConfigInterface $brickConfig): self
+    {
+        $this->addTab(Tab::new($label, [$brickConfig]));
+        return $this;
+    }
+
+    /** @param BrickConfigInterface[] $bricksConfig */
+    public function adds(string $label, array $bricksConfig): self
+    {
+        $this->addTab(Tab::new($label, $bricksConfig));
+        return $this;
+    }
+
+    public function addTab(Tab $tab): self
+    {
+        $this->tabs[] = $tab;
+        return $this;
+    }
+}

--- a/src/Brick/TabBrick/TabFactory.php
+++ b/src/Brick/TabBrick/TabFactory.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lle\CruditBundle\Brick\TabBrick;
+
+use Lle\CruditBundle\Brick\AbstractBasicBrickFactory;
+use Lle\CruditBundle\Builder\BrickBuilder;
+use Lle\CruditBundle\Contracts\BrickConfigInterface;
+use Lle\CruditBundle\Dto\BrickView;
+use Lle\CruditBundle\Resolver\ResourceResolver;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class TabFactory extends AbstractBasicBrickFactory
+{
+    /** @var BrickBuilder  */
+    private $brickBuilder;
+    public function __construct(
+        ResourceResolver $resourceResolver,
+        RequestStack $requestStack,
+        BrickBuilder $brickBuilder
+    ) {
+        $this->brickBuilder = $brickBuilder;
+        parent::__construct($resourceResolver, $requestStack);
+    }
+
+    public function support(BrickConfigInterface $brickConfigurator): bool
+    {
+        return (TabConfig::class === get_class($brickConfigurator));
+    }
+
+    public function buildView(BrickConfigInterface $brickConfigurator): BrickView
+    {
+        $tabs = [];
+        if ($brickConfigurator instanceof TabConfig) {
+            foreach ($brickConfigurator->getTabs() as $k => $tab) {
+                $tabs[$k] = new TabView($tab->getLabel());
+                foreach ($tab->getBrick() as $brickConfig) {
+                    $tabs[$k]->add($this->brickBuilder->buildBrick($brickConfigurator->getCrudConfig(), $brickConfig));
+                }
+            }
+        }
+        $view = new BrickView(spl_object_hash($brickConfigurator));
+        $view
+            ->setTemplate('@LleCrudit/brick/tab')
+            ->setConfig(['tabs' => $tabs])
+            ->setData([]);
+        return $view;
+    }
+}

--- a/src/Brick/TabBrick/TabView.php
+++ b/src/Brick/TabBrick/TabView.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lle\CruditBundle\Brick\TabBrick;
+
+use Lle\CruditBundle\Dto\BrickView;
+
+class TabView
+{
+
+    /** @var BrickView[] */
+    private $bricks;
+
+    /** @var string */
+    private $label;
+
+    public function __construct(string $label)
+    {
+        $this->label = $label;
+        $this->bricks = [];
+    }
+
+    public function setLabel(string $label): self
+    {
+        $this->label = $label;
+        return $this;
+    }
+
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+
+    public function add(BrickView $brickView): self
+    {
+        $this->bricks[] = $brickView;
+        return $this;
+    }
+
+    /** @return BrickView[] */
+    public function getViews(): array
+    {
+        return $this->bricks;
+    }
+
+    public function getId(): string
+    {
+        return md5($this->getLabel());
+    }
+}

--- a/src/Brick/TemplateBrick/TemplateConfig.php
+++ b/src/Brick/TemplateBrick/TemplateConfig.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lle\CruditBundle\Brick\TemplateBrick;
+
+use Lle\CruditBundle\Brick\AbstractBrickConfig;
+
+class TemplateConfig extends AbstractBrickConfig
+{
+
+    /** @var array  */
+    private $options = [];
+
+    public static function new(array $options = []): self
+    {
+        return new self($options);
+    }
+
+    public function __construct(array $options)
+    {
+        $this->options = $options;
+    }
+
+    public function getConfig(): array
+    {
+        return $this->options;
+    }
+}

--- a/src/Brick/TemplateBrick/TemplateFactory.php
+++ b/src/Brick/TemplateBrick/TemplateFactory.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lle\CruditBundle\Brick\TemplateBrick;
+
+use Lle\CruditBundle\Brick\AbstractBasicBrickFactory;
+use Lle\CruditBundle\Dto\BrickView;
+use Lle\CruditBundle\Contracts\BrickConfigInterface;
+use Lle\CruditBundle\Dto\ResourceView;
+
+class TemplateFactory extends AbstractBasicBrickFactory
+{
+
+    public function support(BrickConfigInterface $brickConfigurator): bool
+    {
+        return (TemplateConfig::class === get_class($brickConfigurator));
+    }
+
+    public function buildView(BrickConfigInterface $brickConfigurator): BrickView
+    {
+        /** @var TemplateConfig $brickConfigurator */
+        $view = new BrickView(spl_object_hash($brickConfigurator));
+        $view
+            ->setTemplate('@LleCrudit/brick/template')
+            ->setConfig($brickConfigurator->getConfig())
+            ->setData(['resource' => $this->getResourceView($brickConfigurator)]);
+        return $view;
+    }
+
+    private function getResourceView(TemplateConfig $brickConfigurator): ?ResourceView
+    {
+        $item = $brickConfigurator->getDataSource()->get($this->getRequest()->get('id'));
+        if ($item) {
+            return $this->resourceResolver->resolve(
+                $item,
+                [],
+                $brickConfigurator->getDataSource()
+            );
+        }
+        return null;
+    }
+}

--- a/src/Builder/BrickBuilder.php
+++ b/src/Builder/BrickBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Lle\CruditBundle\Builder;
 
+use Lle\CruditBundle\Contracts\BrickConfigInterface;
 use Lle\CruditBundle\Contracts\CrudConfigInterface;
 use Lle\CruditBundle\Dto\BrickView;
 use Lle\CruditBundle\Exception\UnsupportedBrickConfigurationException;
@@ -29,15 +30,20 @@ class BrickBuilder
     public function build(CrudConfigInterface $crudConfig, string $pageKey, Request $request): array
     {
         foreach ($crudConfig->getBrickConfigs($request, $pageKey) as $brickConfig) {
-            $brickConfig->setCrudConfig($crudConfig);
-            $brickFactory = $this->brickProvider->getBrick($brickConfig);
-            if ($brickFactory) {
-                $this->bricks[] = $brickFactory->buildView($brickConfig);
-            } else {
-                throw new UnsupportedBrickConfigurationException(get_class($brickConfig));
-            }
+            $this->bricks[] = $this->buildBrick($crudConfig, $brickConfig);
         }
         return $this->bricks;
+    }
+
+    public function buildBrick(CrudConfigInterface $crudConfig, BrickConfigInterface $brickConfig): BrickView
+    {
+        $brickConfig->setCrudConfig($crudConfig);
+        $brickFactory = $this->brickProvider->getBrick($brickConfig);
+        if ($brickFactory) {
+            return $brickFactory->buildView($brickConfig);
+        } else {
+            throw new UnsupportedBrickConfigurationException(get_class($brickConfig));
+        }
     }
 
     public function getView(string $id): ?BrickView

--- a/src/Contracts/AbstractCrudAutoConfig.php
+++ b/src/Contracts/AbstractCrudAutoConfig.php
@@ -61,6 +61,6 @@ abstract class AbstractCrudAutoConfig extends AbstractCrudConfig implements Crud
 
     public function getPath(string $context = self::INDEX, array $params = []): Path
     {
-        return Path::new($this->getRootRoute() . '_' . $context, ['ressource' => $this->getName()]);
+        return Path::new($this->getRootRoute() . '_' . $context, ['resource' => $this->getName()]);
     }
 }

--- a/src/Contracts/DatasourceInterface.php
+++ b/src/Contracts/DatasourceInterface.php
@@ -23,11 +23,15 @@ interface DatasourceInterface
 
     public function newInstance(): object;
 
-    public function save(object $ressource): void;
+    public function save(object $resource): void;
 
     public function getClassName(): string;
 
-    public function getType(string $property, object $ressource): string;
+    public function getType(string $property, object $resource): string;
 
-    public function getIdentifier(object $ressource): string;
+    public function getIdentifier(object $resource): string;
+
+    public function createQuery(string $alias): QueryAdapterInterface;
+
+    public function getAssociationFieldName(string $classname): ?string;
 }

--- a/src/Contracts/FieldInterface.php
+++ b/src/Contracts/FieldInterface.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Lle\CruditBundle\Contracts;
 
-use Lle\CruditBundle\Dto\Field\Field;
 use Lle\CruditBundle\Dto\FieldView;
 
 interface FieldInterface
@@ -12,5 +11,5 @@ interface FieldInterface
     public function support(string $type): bool;
 
     /** @param mixed $value */
-    public function buildView(Field $field, $value): FieldView;
+    public function buildView(FieldView $field, $value): FieldView;
 }

--- a/src/Contracts/QueryAdapterInterface.php
+++ b/src/Contracts/QueryAdapterInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lle\CruditBundle\Contracts;
+
+interface QueryAdapterInterface
+{
+    public function where(string $string): self;
+
+    /** @param mixed $value */
+    public function setParameter(string $parameter, $value): self;
+
+    public function execute(): array;
+}

--- a/src/Controller/CrudController.php
+++ b/src/Controller/CrudController.php
@@ -46,7 +46,7 @@ class CrudController extends AbstractController
     }
 
     /**
-     * @Route("/{ressource}")
+     * @Route("/{resource}")
      */
     public function index(Request $request): Response
     {
@@ -60,7 +60,7 @@ class CrudController extends AbstractController
     }
 
     /**
-     * @Route("/{ressource}/show/{id}")
+     * @Route("/{resource}/show/{id}")
      */
     public function show(Request $request): Response
     {
@@ -74,7 +74,7 @@ class CrudController extends AbstractController
     }
 
     /**
-     * @Route("/{ressource}/new")
+     * @Route("/{resource}/new")
      */
     public function new(Request $request): Response
     {
@@ -88,7 +88,7 @@ class CrudController extends AbstractController
     }
 
     /**
-     * @Route("/{ressource}/edit/{id}")
+     * @Route("/{resource}/edit/{id}")
      */
     public function edit(Request $request): Response
     {
@@ -102,7 +102,7 @@ class CrudController extends AbstractController
     }
 
     /**
-     * @Route("/api/{ressource}")
+     * @Route("/api/{resource}")
      */
     public function apiIndex(Request $request): Response
     {
@@ -117,7 +117,7 @@ class CrudController extends AbstractController
     }
 
     /**
-     * @Route("/api/config/{ressource}/{id}")
+     * @Route("/api/config/{resource}/{id}")
      */
     public function apiConfig(string $id): Response
     {
@@ -131,7 +131,7 @@ class CrudController extends AbstractController
     }
 
     /**
-     * @Route("/api/data/{ressource}/{id}")
+     * @Route("/api/data/{resource}/{id}")
      */
     public function apiData(string $id): Response
     {

--- a/src/Controller/DataController.php
+++ b/src/Controller/DataController.php
@@ -29,7 +29,7 @@ class DataController extends AbstractController
     }
 
     /**
-     * @Route("/list/{ressource}")
+     * @Route("/list/{resource}")
      */
     public function index(): Response
     {

--- a/src/Crud/AbstractCrudAutoConfig.php
+++ b/src/Crud/AbstractCrudAutoConfig.php
@@ -31,7 +31,7 @@ abstract class AbstractCrudAutoConfig extends AbstractCrudConfig implements Crud
     {
         return LinkElement::new(
             ucfirst(str_replace('-', ' ', $this->getName() ?? 'menu')),
-            Path::new('lle_crudit_crud_index', ['ressource' => $this->getName()]),
+            Path::new('lle_crudit_crud_index', ['resource' => $this->getName()]),
             Icon::new('circle', Icon::TYPE_FAR)
         );
     }

--- a/src/Datasource/DoctrineQueryAdapter.php
+++ b/src/Datasource/DoctrineQueryAdapter.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lle\CruditBundle\Datasource;
+
+use Doctrine\ORM\QueryBuilder;
+use Lle\CruditBundle\Contracts\QueryAdapterInterface;
+
+class DoctrineQueryAdapter implements QueryAdapterInterface
+{
+    /** @var QueryBuilder  */
+    private $queryBuilder;
+
+    public function __construct(QueryBuilder $queryBuilder)
+    {
+        $this->queryBuilder = $queryBuilder;
+    }
+
+    public function where(string $string): self
+    {
+        $this->queryBuilder->where($string);
+        return $this;
+    }
+
+    /** @param mixed $value */
+    public function setParameter(string $parameter, $value): self
+    {
+        $this->queryBuilder->setParameter($parameter, $value);
+        return $this;
+    }
+
+    public function execute(): array
+    {
+        $return = $this->queryBuilder->getQuery()->execute();
+        if (is_array($return)) {
+            return $return;
+        }
+        return [];
+    }
+}

--- a/src/DependencyInjection/LleCruditExtension.php
+++ b/src/DependencyInjection/LleCruditExtension.php
@@ -6,6 +6,7 @@ namespace Lle\CruditBundle\DependencyInjection;
 
 use Lle\CruditBundle\Contracts\BrickInterface;
 use Lle\CruditBundle\Contracts\CrudConfigInterface;
+use Lle\CruditBundle\Contracts\DatasourceInterface;
 use Lle\CruditBundle\Contracts\FieldInterface;
 use Lle\CruditBundle\Contracts\MenuProviderInterface;
 use Lle\CruditBundle\Layout\LayoutInterface;
@@ -34,6 +35,7 @@ class LleCruditExtension extends Extension implements ExtensionInterface
         $container->registerForAutoconfiguration(LayoutInterface::class)->addTag('crudit.layout');
         $container->registerForAutoconfiguration(MenuProviderInterface::class)->addTag('crudit.menu');
         $container->registerForAutoconfiguration(CrudConfigInterface::class)->addTag('crudit.config');
+        $container->registerForAutoconfiguration(DatasourceInterface::class)->addTag('crudit.datasource');
         $container->registerForAutoconfiguration(BrickInterface::class)->addTag('crudit.brick');
         $container->registerForAutoconfiguration(FieldInterface::class)->addTag('crudit.field');
     }

--- a/src/Dto/FieldView.php
+++ b/src/Dto/FieldView.php
@@ -18,14 +18,46 @@ class FieldView
     /** @var ?string */
     private $stringValue;
 
+    /** @var ?object */
+    private $resource = null;
+
+    /** @var ?object */
+    private $parentResource = null;
+
     /** @param mixed $value */
-    public function __construct(Field $field, $value, ?string $stringValue)
+    public function __construct(Field $field, $value)
     {
         $this->field = $field;
         $this->value = $value;
-        $this->stringValue = $stringValue;
     }
 
+    public function setResource(object $resource): self
+    {
+        $this->resource = $resource;
+        return $this;
+    }
+
+    public function setParentResource(object $resource): self
+    {
+        $this->resource = $resource;
+        return $this;
+    }
+
+    public function getResource(): ?object
+    {
+        return $this->resource;
+    }
+
+    public function getParentResource(): ?object
+    {
+        return $this->parentResource;
+    }
+
+    public function setStringValue(?string $stringValue): self
+    {
+        $this->stringValue = $stringValue;
+        return $this;
+    }
 
     public function getValue(): ?string
     {

--- a/src/Dto/ResourceView.php
+++ b/src/Dto/ResourceView.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Lle\CruditBundle\Dto;
 
-class RessourceView
+class ResourceView
 {
 
     /** @var int|string  */

--- a/src/EventListener/KernelControllerListener.php
+++ b/src/EventListener/KernelControllerListener.php
@@ -46,12 +46,12 @@ class KernelControllerListener
         if (
             is_array($controller) &&
             get_class($controller[0]) === CrudController::class &&
-            $event->getRequest()->attributes->has('ressource') &&
-            $this->configProvider->getConfigurator($event->getRequest()->attributes->get('ressource'))
+            $event->getRequest()->attributes->has('resource') &&
+            $this->configProvider->getConfigurator($event->getRequest()->attributes->get('resource'))
         ) {
             $configurator = $this->configProvider
                 ->getConfigurator(
-                    $event->getRequest()->attributes->get('ressource')
+                    $event->getRequest()->attributes->get('resource')
                 );
             if ($configurator && \is_callable($configurator->getController() . '::' . $controller[1])) {
                 $request->attributes->set('_controller', $configurator->getController() . '::' . $controller[1]);

--- a/src/Field/BooleanField.php
+++ b/src/Field/BooleanField.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Lle\CruditBundle\Field;
 
 use Lle\CruditBundle\Contracts\FieldInterface;
-use Lle\CruditBundle\Dto\Field\Field;
 use Lle\CruditBundle\Dto\FieldView;
 
 class BooleanField implements FieldInterface
@@ -17,12 +16,8 @@ class BooleanField implements FieldInterface
     }
 
     /** @param mixed $value */
-    public function buildView(Field $field, $value): FieldView
+    public function buildView(FieldView $fieldView, $value): FieldView
     {
-        return new FieldView(
-            $field,
-            $value,
-            ($value)? 'crudit.yes':'crudit.no'
-        );
+        return $fieldView->setStringValue(($value) ? 'crudit.yes' : 'crudit.no');
     }
 }

--- a/src/Field/DateField.php
+++ b/src/Field/DateField.php
@@ -18,14 +18,10 @@ class DateField implements FieldInterface
     }
 
     /** @param mixed $value */
-    public function buildView(Field $field, $value): FieldView
+    public function buildView(FieldView $fieldView, $value): FieldView
     {
-        $options = $this->configureOptions($field);
-        return new FieldView(
-            $field,
-            $value,
-            $this->getStringValue($value, $options['format'])
-        );
+        $options = $this->configureOptions($fieldView->getField());
+        return $fieldView->setStringValue($this->getStringValue($value, $options['format']));
     }
 
     /** @param mixed $value */

--- a/src/Field/DoctrineEntityField.php
+++ b/src/Field/DoctrineEntityField.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Lle\CruditBundle\Field;
 
 use Lle\CruditBundle\Contracts\FieldInterface;
-use Lle\CruditBundle\Dto\Field\Field;
 use Lle\CruditBundle\Dto\FieldView;
 
 class DoctrineEntityField implements FieldInterface
@@ -17,12 +16,8 @@ class DoctrineEntityField implements FieldInterface
     }
 
     /** @param mixed $value */
-    public function buildView(Field $field, $value): FieldView
+    public function buildView(FieldView $fieldView, $value): FieldView
     {
-        return new FieldView(
-            $field,
-            $value,
-            (string) $value
-        );
+        return $fieldView->setStringValue((string) $value);
     }
 }

--- a/src/Field/FormatField.php
+++ b/src/Field/FormatField.php
@@ -26,15 +26,15 @@ class FormatField implements FieldInterface
     }
 
     /** @param mixed $value */
-    public function buildView(Field $field, $value): FieldView
+    public function buildView(FieldView $fieldView, $value): FieldView
     {
-        $options = $this->configureOptions($field);
+        $options = $this->configureOptions($fieldView->getField());
         $template = $this->twig->createTemplate($options['format']);
-        return new FieldView(
-            $field,
-            $value,
-            $template->render(['value' => $value])
-        );
+        return $fieldView->setStringValue($template->render([
+            'value' => $value,
+            'view' => $fieldView,
+            'resource' => $fieldView->getResource()
+        ]));
     }
 
     public function configureOptions(Field $field): array

--- a/src/Field/TemplateField.php
+++ b/src/Field/TemplateField.php
@@ -26,14 +26,14 @@ class TemplateField implements FieldInterface
     }
 
     /** @param mixed $value */
-    public function buildView(Field $field, $value): FieldView
+    public function buildView(FieldView $fieldView, $value): FieldView
     {
-        $options = $this->configureOptions($field);
-        return new FieldView(
-            $field,
-            $value,
-            $this->twig->render($options['template'], ['value' => $value])
-        );
+        $options = $this->configureOptions($fieldView->getField());
+        return $fieldView->setStringValue($this->twig->render($options['template'], [
+            'value' => $value,
+            'view' => $fieldView,
+            'resource' => $fieldView->getResource()
+        ]));
     }
 
     public function configureOptions(Field $field): array

--- a/src/Field/TextField.php
+++ b/src/Field/TextField.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Lle\CruditBundle\Field;
 
 use Lle\CruditBundle\Contracts\FieldInterface;
-use Lle\CruditBundle\Dto\Field\Field;
 use Lle\CruditBundle\Dto\FieldView;
 
 class TextField implements FieldInterface
@@ -17,12 +16,8 @@ class TextField implements FieldInterface
     }
 
     /** @param mixed $value */
-    public function buildView(Field $field, $value): FieldView
+    public function buildView(FieldView $fieldView, $value): FieldView
     {
-        return new FieldView(
-            $field,
-            $value,
-            (string) $value
-        );
+        return $fieldView->setStringValue((string) $value);
     }
 }

--- a/src/Layout/AbstractLayout.php
+++ b/src/Layout/AbstractLayout.php
@@ -43,7 +43,7 @@ abstract class AbstractLayout implements LayoutInterface
                 (substr($currentRoute, 0, $positionLastUnderscoreCurrentRoute)) ===
                 (substr($linkRoute, 0, $positionLastUnderscoreLinkRoute));
         } elseif ($item->getPath() !== null &&  $item->getPath()->getRoute() === 'lle_crudit_crud_index') {
-            return $item->getPath()->getParams()['ressource'] === $request->get('ressource');
+            return $item->getPath()->getParams()['resource'] === $request->get('resource');
         }
         return false;
     }

--- a/src/Provider/ConfigProvider.php
+++ b/src/Provider/ConfigProvider.php
@@ -29,10 +29,10 @@ class ConfigProvider
         return $this->configurators[$classname] ?? null;
     }
 
-    public function getConfigurator(string $ressource): ?CrudConfigInterface
+    public function getConfigurator(string $resource): ?CrudConfigInterface
     {
         foreach ($this->configurators as $configurator) {
-            if ($configurator->getName() === $ressource) {
+            if ($configurator->getName() === $resource) {
                 return $configurator;
             }
         }
@@ -46,6 +46,6 @@ class ConfigProvider
 
     public function getConfiguratorByRequest(Request $request): ?CrudConfigInterface
     {
-        return $this->getConfigurator($request->attributes->get('ressource'));
+        return $this->getConfigurator($request->attributes->get('resource'));
     }
 }

--- a/src/Registry/DatasourceRegistry.php
+++ b/src/Registry/DatasourceRegistry.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lle\CruditBundle\Registry;
+
+use Lle\CruditBundle\Contracts\DatasourceInterface;
+use Lle\CruditBundle\Exception\CruditException;
+
+class DatasourceRegistry
+{
+    /** @var DatasourceInterface[] */
+    private $datasources = [];
+
+    public function __construct(iterable $datasources)
+    {
+        foreach ($datasources as $datasource) {
+            $this->datasources[get_class($datasource)] = $datasource;
+        }
+    }
+
+    public function get(string $datasourceClassname): DatasourceInterface
+    {
+        if (array_key_exists($datasourceClassname, $this->datasources)) {
+            return $this->datasources[$datasourceClassname];
+        }
+        throw new CruditException('datasource ' . $datasourceClassname . ' not found');
+    }
+
+    /** @param string $classname */
+    public function getByClass(string $classname): DatasourceInterface
+    {
+        foreach ($this->datasources as $datasource) {
+            if ($datasource->getClassName() === $classname) {
+                return $datasource;
+            }
+        }
+        throw new CruditException('datasource for class ' . $classname . ' not found');
+    }
+}

--- a/src/Resolver/FieldResolver.php
+++ b/src/Resolver/FieldResolver.php
@@ -47,11 +47,11 @@ class FieldResolver
             $type = $datasource->getType($name, $subItem);
             $field->setType($type);
         }
+        $fieldView = (new FieldView($field, $value))
+            ->setResource($item)
+            ->setParentResource($subItem);
         return $this->fieldRegistry->get($type)
-            ->buildView(
-                $field,
-                $value
-            );
+            ->buildView($fieldView, $value);
     }
 
     public function toCamelCase(string $str, bool $capitaliseFirstChar = false): ?string

--- a/src/Resolver/ResourceResolver.php
+++ b/src/Resolver/ResourceResolver.php
@@ -7,9 +7,9 @@ namespace Lle\CruditBundle\Resolver;
 use Lle\CruditBundle\Contracts\DatasourceInterface;
 use Lle\CruditBundle\Dto\Field\Field;
 use Lle\CruditBundle\Dto\FieldView;
-use Lle\CruditBundle\Dto\RessourceView;
+use Lle\CruditBundle\Dto\ResourceView;
 
-class RessourceResolver
+class ResourceResolver
 {
 
     /** @var FieldResolver */
@@ -24,9 +24,9 @@ class RessourceResolver
     /**
      * @param Field[] $fields
      */
-    public function resolve(object $item, array $fields, DatasourceInterface $datasource): RessourceView
+    public function resolve(object $item, array $fields, DatasourceInterface $datasource): ResourceView
     {
-        return new RessourceView(
+        return new ResourceView(
             $datasource->getIdentifier($item),
             $item,
             $this->getFieldViews($fields, $item, $datasource)

--- a/src/Resources/config/bricks.yaml
+++ b/src/Resources/config/bricks.yaml
@@ -1,17 +1,29 @@
 services:
 
   Lle\CruditBundle\Brick\ListBrick\ListFactory:
-    arguments: ['@Lle\CruditBundle\Resolver\RessourceResolver', '@request_stack']
+    arguments: ['@Lle\CruditBundle\Resolver\ResourceResolver', '@request_stack', '@Lle\CruditBundle\Registry\DatasourceRegistry']
     tags: [ 'crudit.brick' ]
 
   Lle\CruditBundle\Brick\ShowBrick\ShowFactory:
-    arguments: ['@Lle\CruditBundle\Resolver\RessourceResolver', '@request_stack']
+    arguments: ['@Lle\CruditBundle\Resolver\ResourceResolver', '@request_stack']
+    tags: [ 'crudit.brick' ]
+
+  Lle\CruditBundle\Brick\TabBrick\TabFactory:
+    arguments: ['@Lle\CruditBundle\Resolver\ResourceResolver', '@request_stack', '@Lle\CruditBundle\Builder\BrickBuilder']
+    tags: [ 'crudit.brick' ]
+
+  Lle\CruditBundle\Brick\TemplateBrick\TemplateFactory:
+    arguments: ['@Lle\CruditBundle\Resolver\ResourceResolver', '@request_stack']
+    tags: [ 'crudit.brick' ]
+
+  Lle\CruditBundle\Brick\ControllerBrick\ControllerFactory:
+    arguments: ['@Lle\CruditBundle\Resolver\ResourceResolver', '@request_stack']
     tags: [ 'crudit.brick' ]
 
   Lle\CruditBundle\Brick\FormBrick\FormFactory:
-    arguments: ['@Lle\CruditBundle\Resolver\RessourceResolver', '@request_stack', '@form.factory', '@Lle\CruditBundle\Brick\BrickResponseCollector', '@router.default']
+    arguments: ['@Lle\CruditBundle\Resolver\ResourceResolver', '@request_stack', '@form.factory', '@Lle\CruditBundle\Brick\BrickResponseCollector', '@router.default']
     tags: [ 'crudit.brick' ]
 
   Lle\CruditBundle\Brick\LinksBrick\LinksFactory:
-    arguments: ['@Lle\CruditBundle\Resolver\RessourceResolver', '@request_stack']
+    arguments: ['@Lle\CruditBundle\Resolver\ResourceResolver', '@request_stack']
     tags: [ 'crudit.brick' ]

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -21,7 +21,7 @@ services:
     Lle\CruditBundle\Resolver\FieldResolver:
         arguments: ['@Lle\CruditBundle\Registry\FieldRegistry',  '@property_accessor']
 
-    Lle\CruditBundle\Resolver\RessourceResolver:
+    Lle\CruditBundle\Resolver\ResourceResolver:
         arguments: ['@Lle\CruditBundle\Resolver\FieldResolver']
 
     Lle\CruditBundle\Provider\LayoutProvider:
@@ -47,6 +47,10 @@ services:
     Lle\CruditBundle\Registry\MenuRegistry:
         arguments:
             - !tagged_iterator crudit.menu
+
+    Lle\CruditBundle\Registry\DatasourceRegistry:
+        arguments:
+            - !tagged_iterator crudit.datasource
 
     Lle\CruditBundle\Layout\AdminLteLayout:
         arguments:

--- a/src/Resources/views/brick/controller/index.html.twig
+++ b/src/Resources/views/brick/controller/index.html.twig
@@ -1,0 +1,1 @@
+{{ render(controller(view.config.controller ,{'resource': view.data.resource})) }}

--- a/src/Resources/views/brick/tab/index.html.twig
+++ b/src/Resources/views/brick/tab/index.html.twig
@@ -1,0 +1,19 @@
+<div class="nav-tabs-custom">
+    <ul class="nav nav-tabs">
+        {% for tab in view.config.tabs %}
+            <li class="nav-item {% if(loop.first) %}active{%  endif %}">
+                <a class="nav-link" href="#_{{ tab.id }}" data-toggle="tab">{{ tab.label|trans }}</a>
+            </li>
+        {%  endfor %}
+    </ul>
+
+    <div class="tab-content">
+        {% for tab in view.config.tabs %}
+                <div id="_{{ tab.id }}" class="tab-pane {% if(loop.first) %}active{%  endif %}">
+                    {%  for view in tab.views %}
+                        {% include view.indexTemplate with { 'view': view } only %}
+                    {%  endfor %}
+                </div>
+        {%  endfor %}
+    </div>
+</div>

--- a/src/Resources/views/brick/template/index.html.twig
+++ b/src/Resources/views/brick/template/index.html.twig
@@ -1,0 +1,1 @@
+{% include view.config.template with {'resource':view.data.resource} %}


### PR DESCRIPTION
petit dev rapide de vacance je fait plus rien après promis.

Cette pull request concerne : 

- ajout des "sublist"
- ajout de la brick controller qui permes l'ajout d'un controller imbriqué
- ajout de la brick template qui permes l'ajout d'un template
- ajout de la brick tab qui permes de gérée des bricks dans des onglets
- le TemplateField et FormatField on acces a l'item (resource)
- renommage ressource -> resource

cette exemple traduit la pullrequest:

```php
$bricks = [
CrudConfigInterface::SHOW => [
                LinksConfig::new()->addBack(),
                ShowConfig::new()->addAuto(['code','libelle','codeEunis','ph','humidite','altitude','proprietaire','histoire','centreLat','centreLng','polygone','commune','groupe','statut']),
                ListConfig::new()->setClassName(Collecte::class)->addAuto(['id','numeroFiche']),
                TabConfig::new()
                    ->add('foo',TemplateConfig::new(['template' => 'foo.html.twig']))
                    ->add('test', ControllerConfig::new(['controller' => SiteCollecteController::class .'::test']))
            ]
]
```

* setdatasource peux être utilisé a la place de setClassName 
* l' association peux être customisé avec les nouveau setter de ListConfig mais dans la plus part des cas l'exemple suffit.

TemplateBrick et controllerBrick sont en gros des customBrick si elle ne suffise pas ou qu'il dois y avoir réutilisation le client devra crée ça propre brick.