### PR TITLE
fix: label inconsistency between lists and forms

### DIFF
--- a/src/Form/DoctrineOrmTypeGuesser.php
+++ b/src/Form/DoctrineOrmTypeGuesser.php
@@ -39,8 +39,9 @@ class DoctrineOrmTypeGuesser implements FormTypeGuesserInterface
      */
     public function guessType(string $class, string $property)
     {
+        $label = "field." . strtolower(str_replace('.', '_', $property));
         if (!$ret = $this->getMetadata($class)) {
-            return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\TextType', ["label"=>"field.".$property], Guess::LOW_CONFIDENCE);
+            return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\TextType', ["label" => $label], Guess::LOW_CONFIDENCE);
         }
 
         [$metadata, $name] = $ret;
@@ -52,45 +53,47 @@ class DoctrineOrmTypeGuesser implements FormTypeGuesserInterface
             return new TypeGuess('Lle\CruditBundle\Form\Type\AutocompleteType', [
                 'class' => $mapping['targetEntity'],
                 'multiple' => $multiple,
-                "label"=>"field.".$property], Guess::HIGH_CONFIDENCE);
+                "label" => $label,
+            ], Guess::HIGH_CONFIDENCE);
         }
+
         switch ($metadata->getTypeOfField($property)) {
             case Types::ARRAY:
             case Types::SIMPLE_ARRAY:
-                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\CollectionType', ["label"=>"field.".$property], Guess::MEDIUM_CONFIDENCE);
+                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\CollectionType', ["label" => $label], Guess::MEDIUM_CONFIDENCE);
             case Types::BOOLEAN:
-                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\CheckboxType', ["label"=>"field.".$property], Guess::HIGH_CONFIDENCE);
+                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\CheckboxType', ["label" => $label], Guess::HIGH_CONFIDENCE);
             case Types::DATETIME_MUTABLE:
             case Types::DATETIMETZ_MUTABLE:
             case 'vardatetime':
-                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\DateTimeType', ["label"=>"field.".$property], Guess::HIGH_CONFIDENCE);
+                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\DateTimeType', ["label" => $label], Guess::HIGH_CONFIDENCE);
             case Types::DATETIME_IMMUTABLE:
             case Types::DATETIMETZ_IMMUTABLE:
-                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\DateTimeType', ['input' => 'datetime_immutable',"label"=>"field.".$property], Guess::HIGH_CONFIDENCE);
+                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\DateTimeType', ['input' => 'datetime_immutable', "label" => $label], Guess::HIGH_CONFIDENCE);
             case Types::DATEINTERVAL:
-                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\DateIntervalType', ["label"=>"field.".$property], Guess::HIGH_CONFIDENCE);
+                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\DateIntervalType', ["label" => $label], Guess::HIGH_CONFIDENCE);
             case Types::DATE_MUTABLE:
-                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\DateType', ["label"=>"field.".$property], Guess::HIGH_CONFIDENCE);
+                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\DateType', ["label" => $label], Guess::HIGH_CONFIDENCE);
             case Types::DATE_IMMUTABLE:
-                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\DateType', ['input' => 'datetime_immutable',"label"=>"field.".$property], Guess::HIGH_CONFIDENCE);
+                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\DateType', ['input' => 'datetime_immutable', "label" => $label], Guess::HIGH_CONFIDENCE);
             case Types::TIME_MUTABLE:
-                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\TimeType', ["label"=>"field.".$property], Guess::HIGH_CONFIDENCE);
+                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\TimeType', ["label" => $label], Guess::HIGH_CONFIDENCE);
             case Types::TIME_IMMUTABLE:
-                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\TimeType', ['input' => 'datetime_immutable',"label"=>"field.".$property], Guess::HIGH_CONFIDENCE);
+                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\TimeType', ['input' => 'datetime_immutable', "label" => $label], Guess::HIGH_CONFIDENCE);
             case Types::DECIMAL:
-                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\NumberType', ['input' => 'string',"label"=>"field.".$property], Guess::MEDIUM_CONFIDENCE);
+                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\NumberType', ['input' => 'string', "label" => $label], Guess::MEDIUM_CONFIDENCE);
             case Types::FLOAT:
-                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\NumberType', ["label"=>"field.".$property], Guess::MEDIUM_CONFIDENCE);
+                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\NumberType', ["label" => $label], Guess::MEDIUM_CONFIDENCE);
             case Types::INTEGER:
             case Types::BIGINT:
             case Types::SMALLINT:
-                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\IntegerType', ["label"=>"field.".$property], Guess::MEDIUM_CONFIDENCE);
+                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\IntegerType', ["label" => $label], Guess::MEDIUM_CONFIDENCE);
             case Types::STRING:
-                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\TextType', ["label"=>"field.".$property], Guess::MEDIUM_CONFIDENCE);
+                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\TextType', ["label" => $label], Guess::MEDIUM_CONFIDENCE);
             case Types::TEXT:
-                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\TextareaType', ["label"=>"field.".$property], Guess::MEDIUM_CONFIDENCE);
+                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\TextareaType', ["label" => $label], Guess::MEDIUM_CONFIDENCE);
             default:
-                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\TextType', ["label"=>"field.".$property], Guess::LOW_CONFIDENCE);
+                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\TextType', ["label" => $label], Guess::LOW_CONFIDENCE);
         }
     }
 


### PR DESCRIPTION
e.g. : mobilePhone

list has field.mobilephone
form has field.mobilePhone

=> now they both have the same label