### PR TITLE
Bug : value with empty string in edit_in_place

### DIFF
--- a/src/Controller/TraitCrudController.php
+++ b/src/Controller/TraitCrudController.php
@@ -154,6 +154,10 @@ trait TraitCrudController
                     continue;
                 }
 
+                if ($value === "") {
+                    $value = null;
+                }
+
                 $propertyAccessor->setValue($item, $field, $value);
             }
 


### PR DESCRIPTION
When we have an empty value in the edit_in_place, we have an error : "Expected argument of type "float or null", "string" given"