### PR TITLE
Improvement/remove autocomplete

### DIFF
--- a/src/Resources/views/brick/form/index.html.twig
+++ b/src/Resources/views/brick/form/index.html.twig
@@ -5,7 +5,7 @@
         <div class="table-responsive">
             {{ form_errors(form) }}
             {% for field in form.getIterator() %}
-                {{ form_row(field, {'attr': {'autocomplete': 'no'}}) }}
+                {{ form_row(field, {'attr': {'autocomplete': 'new-password'}}) }}
             {% endfor %}
         </div>
     </div>

--- a/src/Resources/views/brick/form/index.html.twig
+++ b/src/Resources/views/brick/form/index.html.twig
@@ -1,11 +1,11 @@
 {% set form = view.data.form %}
 <div class="card shadow mb-4">
-    {{ form_start(form, {'attr': {'class': 'form-horizontal', 'novalidate': 'novalidate'}}) }}
+    {{ form_start(form, {'attr': {'class': 'form-horizontal', 'novalidate': 'novalidate', 'autocomplete': 'off'}}) }}
     <div class="card-body">
         <div class="table-responsive">
             {{ form_errors(form) }}
             {% for field in form.getIterator() %}
-                {{ form_row(field) }}
+                {{ form_row(field, {'attr': {'autocomplete': 'no'}}) }}
             {% endfor %}
         </div>
     </div>


### PR DESCRIPTION
Autocomplete attribute is set on the `<form>` to `off`.
Especially for Google Chrome, autocomplete attribute is set on each `<input>` to `new-password` (this is W3C valid)