### PR TITLE
Fix menu bold on hover

### DIFF
--- a/assets/sb-admin/css/navs/_sidebar.scss
+++ b/assets/sb-admin/css/navs/_sidebar.scss
@@ -14,7 +14,6 @@ $icon-width: 32px;
         &.active, &:hover {
             background-color: lighten($primary, 10%);
             .nav-link {
-                font-weight: 700;
                 img {
                     filter: grayscale(0);
                 }
@@ -70,7 +69,7 @@ $icon-width: 32px;
                 position: relative;
                 top: 0;
                 left: 0;
-                margin: 0 1rem;
+                margin: 0 1rem 10px 1rem;
                 background-color: transparent;
                 z-index: 1;
             }
@@ -106,7 +105,6 @@ $icon-width: 32px;
                 &.active {
                     color: $white;
                     background-color: lighten($primary, 20%);
-                    font-weight: 700;
                 }
 
                 span {


### PR DESCRIPTION
Avoid menu item goes on 2 lines on hover because of font-weight changes