### PR TITLE
Fix linked collapses

### DIFF
--- a/assets/sb-admin/css/components/forms/_filter.scss
+++ b/assets/sb-admin/css/components/forms/_filter.scss
@@ -67,7 +67,7 @@ $input-group-prepend-length: 60px;
 }
 
 
-#collapse-filter {
+#collapse-filters {
     .btn {
         .less-filter {
             display: none;

--- a/assets/sb-admin/css/components/navs/_sidebar.scss
+++ b/assets/sb-admin/css/components/navs/_sidebar.scss
@@ -39,9 +39,9 @@ $icon-width: 32px;
                 text-align: left;
                 padding: 1rem;
                 width: $sidebar-base-width;
-                &[data-bs-toggle='collapse'] {
+                &[data-bs-toggle="collapse"] {
                     &::after {
-                        content: '\f107';
+                        content: '\f105';
                         width: 1rem;
                         float: right;
                         color: fade-out($white, 0.5);
@@ -52,7 +52,7 @@ $icon-width: 32px;
                     }
 
                     &.collapsed::after {
-                        content: '\f105';
+                        content: '\f107';
                     }
                 }
             }

--- a/src/Resources/views/brick/filter/index.html.twig
+++ b/src/Resources/views/brick/filter/index.html.twig
@@ -5,7 +5,7 @@
                 <i class="icon fa fa-search"></i>&nbsp;
                 {{ 'crudit.title.filter'|trans(domain='LleCruditBundle') }}
             </h6>
-            <span class="btn float-end card-toggle" data-bs-toggle="collapse" data-bs-target="#collapse-filter" aria-expanded="true" aria-controls="collapse-filter">
+            <span class="btn float-end card-toggle" data-bs-toggle="collapse" data-bs-target="#collapse-filters" aria-expanded="true" aria-controls="collapse-filters">
                 <i class="fa fa-chevron-up"></i>
             </span>
             {% for id, filter in view.data.filters %}
@@ -17,7 +17,7 @@
             {% endfor %}
         </div>
 
-        <div id="collapse-filter" class="collapse show">
+        <div id="collapse-filters" class="collapse show">
             <div class="card-body">
                 <div class="row">
                     {% set isCollapsedFilters = false %}
@@ -29,7 +29,7 @@
                             {% set isCollapsedFilters = true %}
                         {% endif %}
 
-                        <div class="{{ classes }}">
+                        <div id="filter-{{ loop.index }}" class="{{ classes }}">
                             {% include filter.template with {
                                 'data': filter.data,
                                 'id': 'filter_' ~ id,


### PR DESCRIPTION
The id set on each filter is mandatory to avoid that many collapse being linked each other. They were linked because we are using a `data-bs-target` with a class to manage this collapse.