### PR TITLE
add multi worflow par entite

### DIFF
--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -56,6 +56,7 @@ services:
             - '@router'
             - '@doctrine.orm.entity_manager'
             - '@parameter_bag'
+            - '@workflow.registry'
         tags: [twig.extension]
 
     Lle\CruditBundle\Twig\CruditTelephoneCallFilterExtension:

--- a/src/Resources/views/field/workflow.html.twig
+++ b/src/Resources/views/field/workflow.html.twig
@@ -1,9 +1,12 @@
 {# Get allowed transitions #}
 
-{% set transitions = workflow_transitions(resource, options.name|default(null)) %}
+{% set workflow_name = options.name|default(get_workflow_names(resource)|first) %}
+
+{% set transitions = workflow_transitions(resource, workflow_name) %}
+
 {# Filter by user role #}
 {% if view.config %}
-    {% set transitions = transitions | filter(t => is_granted('ROLE_' ~ (view.config.name) ~ '_WF_' ~ (t.name | upper | replace({'-': '_'})))) %}
+    {% set transitions = transitions | filter(t => is_granted('ROLE_' ~ (workflow_name|upper) ~ '_WF_' ~ (t.name | upper | replace({'-': '_'})))) %}
 {% endif %}
 
 {% if transitions is not empty %}

--- a/src/Twig/CruditExtension.php
+++ b/src/Twig/CruditExtension.php
@@ -12,6 +12,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Workflow\Registry;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
@@ -23,6 +24,7 @@ class CruditExtension extends AbstractExtension
         private RouterInterface $router,
         private EntityManagerInterface $em,
         private ParameterBagInterface $parameterBag,
+        private Registry $workflowRegistry,
     ) {
     }
 
@@ -32,7 +34,7 @@ class CruditExtension extends AbstractExtension
             new TwigFunction('crudit_menu_items', [$this, 'menuItems']),
             new TwigFunction('crudit_menu_active', [$this, 'menuIsActive']),
             new TwigFunction('crudit_hide_if_disabled', [$this, 'hideIfDisabled']),
-
+            new TwigFunction('get_workflow_names', $this->getWorkflowNames(...))
         ];
     }
 
@@ -156,5 +158,17 @@ class CruditExtension extends AbstractExtension
         }
 
         return $hideIfDisabled;
+    }
+
+    public function getWorkflowNames(object $subject): array
+    {
+        $workflows = $this->workflowRegistry->all($subject);
+
+        $result = [];
+        foreach ($workflows as $workflow) {
+            $result[] = $workflow->getName();
+        }
+
+        return $result;
     }
 }


### PR DESCRIPTION
(Nathan)

contexte: le warmup droits de crudit-platform prend le nom du WF et pas l'entité, pour les rôles WF, alors que crudit prend l'entité

et de toute manière il faudrait mettre le nom du WF pour des raisons de cohérence.

Sauf qu'on peut pas avoir les noms de WF en twig, j'ai dû coder une fonction twig pour faire ça. Par défaut ça prend le 1er wf existant, sinon celui configuré par le dev.