### PR TITLE
Update layout.html.twig

### DIFF
--- a/src/Resources/views/layout/sb_admin/layout.html.twig
+++ b/src/Resources/views/layout/sb_admin/layout.html.twig
@@ -36,7 +36,7 @@
             </ul>
         </div>
 
-        <div id="content-wrapper" class="d-flex flex-column">
+        <div id="content-wrapper" class="d-flex flex-column min-vh-100">
             <div id="content">
                 {% block header %}
                     {% include '@LleCrudit/layout/sb_admin/header.html.twig' %}


### PR DESCRIPTION
Content can now take 100% of the height, means smaller footer : 

![image](https://github.com/user-attachments/assets/5fc307c8-222f-4059-ad81-a864d15e1e9d)

vs

![image](https://github.com/user-attachments/assets/e9e8620d-4b04-4878-8365-13b1fab3412d)

