### PR TITLE
fix(exporter): restore the body marker expected by the Mpdf writer

### DIFF
--- a/src/Exporter/PdfExporter.php
+++ b/src/Exporter/PdfExporter.php
@@ -20,6 +20,19 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class PdfExporter extends AbstractExporter
 {
+    /**
+     * Marker Mpdf::save() looks for to know where the document body starts. Kept as a literal
+     * instead of Mpdf::SIMULATED_BODY_START because that constant only exists since
+     * PhpSpreadsheet 2.0, while this bundle also supports 1.30. On 1.30 the marker is an inert
+     * HTML comment: the writer still falls back to sending the HTML in chunks of 1000 lines,
+     * which keeps the <style> block inside a single WriteHTML() call.
+     */
+    public const SIMULATED_BODY_START = '<!-- simulated body start -->';
+
+    /** Needles rewritten in the HTML produced by the spreadsheet writer. */
+    private const PAGE_DECLARATION = '@page page0 {';
+    private const BODY_TAG = '<body>';
+
     public function __construct(
         protected TranslatorInterface $translator,
     ) {
@@ -235,8 +248,12 @@ class PdfExporter extends AbstractExporter
                     odd-footer-name: html_myFooter2;
                     even-footer-name: html_myFooter2;                   
                 EOF;
-            $html = preg_replace('/@page page0 {/', $pagerepl, $html) ?? '';
-            $bodystring = '/<body>/';
+            // str_replace, not preg_replace: both needles are literals, and the injected header
+            // and footer values are free text from the crud config. As a replacement string,
+            // preg_replace() would read $1, \1 and \\ in them as backreferences and silently
+            // drop part of the value.
+            $html = str_replace(self::PAGE_DECLARATION, $pagerepl, $html);
+            $bodystring = self::BODY_TAG;
             $topLeft = $params['header-left'] ?? '';
             $topCenter = $params['header-center'] ?? '';
             $topRight = $params['header-right'] ?? '';
@@ -249,6 +266,14 @@ class PdfExporter extends AbstractExporter
             $sizeBL = $params['size-footer-left'] ?? 'medium';
             $sizeBC = $params['size-footer-center'] ?? 'medium';
             $sizeBR = $params['size-footer-right'] ?? 'medium';
+
+            // Rewriting the <body> tag removes the marker Mpdf::save() looks for to locate the
+            // start of the document body. Without it the whole HTML - <head> and <style>
+            // included - is pushed to mPDF one line at a time (PhpSpreadsheet >= 2.0), which
+            // prints the stylesheet as plain text instead of applying it. Closing the injected
+            // block with the marker gives the writer back a split point, so the head and the
+            // page header/footer tags are written in a single WriteHTML() call.
+            $simulatedBodyStart = self::SIMULATED_BODY_START;
 
             $bodyrepl = <<<EOF
                     <body style="font-family: 'Arial';">
@@ -271,10 +296,10 @@ class PdfExporter extends AbstractExporter
                                 </tr>
                             </table>
                         </htmlpagefooter>
-                    
+                        $simulatedBodyStart
                     EOF;
 
-            return preg_replace($bodystring, $bodyrepl, $html) ?? '';
+            return str_replace($bodystring, $bodyrepl, $html);
         };
     }
 

--- a/tests/phpunit/Unit/Exporter/PdfExporterTest.php
+++ b/tests/phpunit/Unit/Exporter/PdfExporterTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace phpunit\Unit\Exporter;
+
+use Lle\CruditBundle\Exporter\PdfExporter;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Pdf\Mpdf;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class PdfExporterTest extends TestCase
+{
+    private const HEADER_FOOTER = [
+        'header-left' => 'Establishment',
+        'header-center' => 'Payment list',
+        'header-right' => 'Page {PAGENO} of {nbpg}',
+        'footer-left' => 'Exported by dev',
+        'footer-center' => 'Crudit',
+        'footer-right' => 'No filter',
+    ];
+
+    /**
+     * Mpdf::save() splits the HTML on a body marker: everything before it goes to mPDF in a
+     * single WriteHTML() call, the rest one line at a time. Since the callback rewrites the
+     * <body> tag, it has to restore that marker, otherwise the <head> - and its <style> block -
+     * is fed to mPDF line by line and printed as plain text instead of being applied.
+     */
+    public function testHeaderAndFooterCallbackKeepsBodySplitPoint(): void
+    {
+        $html = $this->generateHtml();
+        $bodyLocation = strpos($html, PdfExporter::SIMULATED_BODY_START);
+
+        self::assertNotFalse($bodyLocation, 'The body split point expected by Mpdf::save() is missing.');
+
+        $firstChunk = substr($html, 0, $bodyLocation);
+        self::assertStringContainsString('<style', $firstChunk);
+        self::assertStringContainsString('<htmlpageheader name="myHeader1"', $firstChunk);
+        self::assertStringContainsString('<htmlpagefooter name="myFooter2"', $firstChunk);
+    }
+
+    /**
+     * The marker is duplicated in the exporter because PhpSpreadsheet only exposes it since 2.0.
+     * Whenever the writer does expose it, both values must stay in sync.
+     */
+    public function testSimulatedBodyStartMatchesTheWriterMarker(): void
+    {
+        if (!defined(Mpdf::class . '::SIMULATED_BODY_START')) {
+            self::markTestSkipped('PhpSpreadsheet < 2.0 does not expose the marker.');
+        }
+
+        self::assertSame(Mpdf::SIMULATED_BODY_START, PdfExporter::SIMULATED_BODY_START);
+    }
+
+    public function testHeaderAndFooterCallbackInjectsPageHeaderAndFooter(): void
+    {
+        $html = $this->generateHtml();
+
+        self::assertStringContainsString('odd-header-name: html_myHeader1;', $html);
+        self::assertStringContainsString('odd-footer-name: html_myFooter2;', $html);
+        foreach (self::HEADER_FOOTER as $value) {
+            self::assertStringContainsString($value, $html);
+        }
+    }
+
+    /**
+     * Header and footer values come from the crud config, so they can hold any character. They
+     * are injected into the replacement string, where $1, \1 and \\ would be read as
+     * backreferences by preg_replace() and silently swallow part of the value.
+     *
+     * @dataProvider provideSpecialCharacters
+     */
+    public function testHeaderAndFooterCallbackKeepsSpecialCharacters(string $value): void
+    {
+        $html = $this->generateHtml(['header-left' => $value]);
+
+        self::assertStringContainsString($value, $html);
+    }
+
+    /** @return array<string, array{string}> */
+    public function provideSpecialCharacters(): array
+    {
+        return [
+            'backslash' => ['C:\\exports\\2026'],
+            'backslash followed by a digit' => ['Filter \\1 enabled'],
+            'dollar followed by a digit' => ['Amount $1 net'],
+            'double backslash' => ['a\\\\b'],
+            'ampersand' => ['Durand & Sons'],
+        ];
+    }
+
+    private function generateHtml(array $headerFooter = []): string
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $exporter = new PdfExporter($translator);
+
+        $spreadsheet = new Spreadsheet();
+        $spreadsheet->getActiveSheet()->setCellValue('A1', 'Value');
+
+        $writer = new Mpdf($spreadsheet);
+        $writer->setEditHtmlCallback(
+            $exporter->getHeaderAndFooter($headerFooter + self::HEADER_FOOTER)
+        );
+
+        return $writer->generateHtmlAll();
+    }
+}


### PR DESCRIPTION
The header/footer callback rewrites the <body> tag, which removed the split point PhpSpreadsheet\Writer\Pdf\Mpdf::save() looks for. Since PhpSpreadsheet 2.0 the fallback pushes the HTML to mPDF one line at a time, so the <style> block is no longer parsed as CSS and gets printed as plain text: every PDF export came out with the stylesheet spelled out over the first pages and no formatting at all.

The injected block now ends with the marker the writer expects. It is declared as a bundle constant rather than reusing Mpdf::SIMULATED_BODY_START, because that constant only exists since PhpSpreadsheet 2.0 while composer.json still allows ^1.30 - referencing it there would turn a broken export into a fatal error. On 1.30 the marker is an inert HTML comment and the writer keeps falling back to 1000-line chunks, which works.

Both injections also move from preg_replace to str_replace: the needles are literals, and the header/footer values coming from the crud config were read as backreferences ($1, \1, \\) in the replacement string, silently dropping part of the footer.